### PR TITLE
add devops team

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -518,6 +518,10 @@ export default {
                       label: "Dependencies",
                     },
                     {
+                      id: "devops",
+                      label: "DevOps",
+                    },
+                    {
                         id: "epos",
                         label: "EPOS team",
                     },
@@ -560,10 +564,6 @@ export default {
                     {
                         id: "projects",
                         label: "Projects",
-                    },
-                    {
-                        id: "systems_engineering",
-                        label: "Systems Engineering",
                     },
                     {
                       id: "value_added",


### PR DESCRIPTION
The Systems Engineering team branch has been retired in favour of `team/devops`. This PR updates the generator. 